### PR TITLE
Refactor make_cal.py for testability, add unit tests

### DIFF
--- a/python/CLAUDE.md
+++ b/python/CLAUDE.md
@@ -10,10 +10,13 @@ This script generates a circular calendar that overlays the Islamic (Hijri) luna
 python -m venv .venv
 source .venv/bin/activate
 pip install --no-deps -r requirements.txt
+pip install cffi   # required by pypdf but not in requirements.txt
 python make_cal.py
 ```
 
-Note: The `--no-deps` flag is required to prevent svglib from pulling in pycairo, which requires system libraries. All actual runtime dependencies are explicitly listed in requirements.txt.
+Note: The `--no-deps` flag is required to prevent svglib from pulling in pycairo, which requires system libraries. All actual runtime dependencies are explicitly listed in requirements.txt. The `cffi` package is needed at runtime by `pypdf` but isn't listed as a direct dependency.
+
+To visually inspect the generated PDF, install `poppler-utils` (`apt-get install poppler-utils`) and use `pdftoppm`.
 
 Output: `out/calendar_pages_0.7_COMPLETE.pdf` - a single PDF containing:
 1. Instructions page with embedded circular calendar preview image
@@ -110,6 +113,8 @@ source .venv/bin/activate
 pip install pytest
 python -m pytest -v
 ```
+
+Tests run in ~0.3s with no file I/O. After making changes, always generate a calendar (`python make_cal.py`) and visually verify the output PDF to catch rendering issues that unit tests can't detect.
 
 ## PDF Generation Pipeline
 

--- a/python/CLAUDE.md
+++ b/python/CLAUDE.md
@@ -78,6 +78,7 @@ These values are calculated automatically:
 ## File Structure
 
 - `make_cal.py` - Main script, CLI interface, orchestrates PDF generation
+- `layout.py` - Pure layout computation (dimensions, pagination, month instance building)
 - `islamic_alignment.py` - Auto-alignment calculation using hijridate library
 - `calendar_data.py` - Month definitions, colors, canonical month order
 - `calendar_drawings.py` - SVG rendering for month arcs
@@ -85,6 +86,10 @@ These values are calculated automatically:
 - `primitives.py` - Data structures (Point, Arc, etc.)
 - `pdfizer.py` - PDF concatenation utility
 - `generate_instructions.py` - Generates instructions PDF with embedded cover image
+- `test_cal.py` - Unit tests for primitives and arc drawing
+- `test_layout.py` - Unit tests for layout calculations and month instance building
+- `test_arc_drawing.py` - Unit tests for geometric calculations
+- `test_calendar_drawings.py` - Unit tests for month SVG rendering
 - `test_islamic_alignment.py` - Unit tests for alignment module
 
 ## Running Tests
@@ -92,7 +97,7 @@ These values are calculated automatically:
 ```bash
 source .venv/bin/activate
 pip install pytest
-python -m pytest test_islamic_alignment.py -v
+python -m pytest -v
 ```
 
 ## PDF Generation Pipeline

--- a/python/CLAUDE.md
+++ b/python/CLAUDE.md
@@ -75,9 +75,20 @@ These values are calculated automatically:
 - `days_elapsed_islamic` - Days from January 1 to start of current Islamic month
 - `islamic_date_rotation_offset` - Approximately the negative of days_elapsed
 
+## Architecture
+
+Pure computation is separated from I/O so modules can be imported and tested independently:
+
+- **`make_cal.py`** wraps all orchestration (CLI parsing, file I/O, PDF generation) in a `main()` function. Importing it does **not** trigger calendar generation — `main()` only runs via `__main__` or when in a Jupyter notebook.
+- **`layout.py`** contains the pure layout computation extracted from `make_cal.py`: layout dimensions from scale factor, pagination logic, and `MonthInstance` list building for both solar and Islamic calendars. All functions are side-effect-free.
+- **`islamic_alignment.py`** is also pure computation (date math), separate from rendering.
+- **`calendar_drawings.py`** and **`arc_drawing.py`** handle SVG element generation — they produce data structures, not files.
+
+Tests import from specific modules (`primitives`, `arc_drawing`, `layout`, etc.) rather than from `make_cal`, so they run fast (~0.3s) with no file I/O.
+
 ## File Structure
 
-- `make_cal.py` - Main script, CLI interface, orchestrates PDF generation
+- `make_cal.py` - Main script, CLI interface, orchestrates PDF generation (all in `main()`)
 - `layout.py` - Pure layout computation (dimensions, pagination, month instance building)
 - `islamic_alignment.py` - Auto-alignment calculation using hijridate library
 - `calendar_data.py` - Month definitions, colors, canonical month order

--- a/python/layout.py
+++ b/python/layout.py
@@ -1,0 +1,146 @@
+"""
+Layout calculation module for circular calendar.
+
+Pure computation functions extracted from make_cal.py for testability.
+Handles layout dimensions, month instance creation, pagination, and
+geometric transformations - all without side effects.
+"""
+
+from typing import List, NamedTuple, Tuple
+
+from primitives import Point, SCALE_FACTOR
+from arc_drawing import inchToMilimeter
+from calendar_data import MonthInstance, Month, Year
+
+
+class LayoutParams(NamedTuple):
+    """Computed layout dimensions for the calendar."""
+    scale_factor: float
+    canvas_width: float
+    width: float
+    outermost_radius: float
+    inner_radius: float
+    month_thickness: float
+    date_box_height: float
+    width_center: float
+    vertical_offset: float
+    origin: Point
+    month_offset: float
+    num_rows: int
+    num_columns: int
+
+
+def calculate_layout_params(scale_factor: float = SCALE_FACTOR) -> LayoutParams:
+    """Calculate all layout dimensions from scale factor."""
+    canvas_width = 11 * scale_factor
+    width = inchToMilimeter(8 * scale_factor)
+    outermost_radius = width / (2 * 3.14 / 12)
+    inner_radius = outermost_radius * 9.2 / 10
+    month_thickness = outermost_radius - inner_radius
+    date_box_height = month_thickness * 0.2
+
+    extra_width_offset = 10
+    width_center = inchToMilimeter(canvas_width) / 2 + extra_width_offset
+    vertical_offset = 30 * scale_factor
+
+    origin = Point(width_center, outermost_radius + vertical_offset)
+    month_offset = 4 * scale_factor
+
+    num_rows, num_columns = get_pagination(scale_factor)
+
+    return LayoutParams(
+        scale_factor=scale_factor,
+        canvas_width=canvas_width,
+        width=width,
+        outermost_radius=outermost_radius,
+        inner_radius=inner_radius,
+        month_thickness=month_thickness,
+        date_box_height=date_box_height,
+        width_center=width_center,
+        vertical_offset=vertical_offset,
+        origin=origin,
+        month_offset=month_offset,
+        num_rows=num_rows,
+        num_columns=num_columns,
+    )
+
+
+def get_pagination(scale_factor: float) -> Tuple[int, int]:
+    """Return (num_rows, num_columns) based on scale factor."""
+    if scale_factor <= 0.5:
+        return 5, 2
+    elif scale_factor < 0.75:
+        return 4, 1
+    else:
+        return 2, 1
+
+
+def date_rotation(month: Month) -> int:
+    """Calculate the date angle offset for a month based on its position number."""
+    return -1 * (month.number - 1) * (360 / 12)
+
+
+def offset_point_by(point: Point, x_offset: float, y_offset: float) -> Point:
+    """Translate a point by the given offsets."""
+    return Point(point.x + x_offset, point.y + y_offset)
+
+
+def calculate_circle_rotation(days_elapsed: float, num_days: int, days_in_year: int) -> float:
+    """Calculate rotation angle for placing a month on the circular calendar."""
+    return 360.0 * (days_elapsed + num_days / 2) / days_in_year
+
+
+def build_solar_month_instances(
+    solar_year: Year,
+    date_box_height: float,
+    inner_radius: float,
+    outermost_radius: float,
+) -> List[MonthInstance]:
+    """Build MonthInstance list for solar (Gregorian) calendar months."""
+    solar_months = []
+    for index, month in enumerate(solar_year.months):
+        name_upside_down = (index >= 3 and index < 9)
+        for day in month.num_days:
+            solar_months.append(
+                MonthInstance(
+                    name=month.name,
+                    num_days=day,
+                    color=month.color,
+                    name_upside_down=name_upside_down,
+                    date_on_top=False,
+                    date_box_height=date_box_height,
+                    inner_radius=inner_radius,
+                    outer_radius=outermost_radius,
+                    date_angle_offset=date_rotation(month),
+                )
+            )
+    return solar_months
+
+
+def build_islamic_month_instances(
+    islamic_year: Year,
+    date_box_height: float,
+    inner_radius: float,
+    outermost_radius: float,
+    month_thickness: float,
+    islamic_date_rotation_offset: float,
+) -> List[MonthInstance]:
+    """Build MonthInstance list for Islamic (Hijri) calendar months."""
+    islamic_months = []
+    for month in islamic_year.months:
+        name_upside_down = (month.number > 3 and month.number <= 9)
+        for day in month.num_days:
+            islamic_months.append(
+                MonthInstance(
+                    name=month.name,
+                    num_days=day,
+                    color=month.color,
+                    name_upside_down=name_upside_down,
+                    date_on_top=True,
+                    date_box_height=date_box_height,
+                    inner_radius=inner_radius - month_thickness,
+                    outer_radius=outermost_radius - month_thickness,
+                    date_angle_offset=date_rotation(month) + islamic_date_rotation_offset,
+                )
+            )
+    return islamic_months

--- a/python/make_cal.py
+++ b/python/make_cal.py
@@ -37,6 +37,14 @@ from primitives import *
 from arc_drawing import *
 from calendar_data import *
 from calendar_drawings import *
+from layout import (
+    calculate_layout_params,
+    date_rotation,
+    offset_point_by as offsetPointBy,
+    build_solar_month_instances,
+    build_islamic_month_instances,
+    calculate_circle_rotation,
+)
 import islamic_alignment
 import pdfizer
 
@@ -85,234 +93,175 @@ def get_alignment_from_args(args) -> islamic_alignment.AlignmentParams:
         return islamic_alignment.get_alignment_params()
 
 
-# Parse arguments and calculate alignment
-args = parse_args()
-alignment = get_alignment_from_args(args)
-islamic_alignment.print_alignment_info(alignment)
+def main():
+    # Parse arguments and calculate alignment
+    args = parse_args()
+    alignment = get_alignment_from_args(args)
+    islamic_alignment.print_alignment_info(alignment)
 
-# Rotate Islamic months to start with current month
-islamic_year = Year(
-    months=islamic_alignment.rotate_months(
-        islamic_year_canonical.months, alignment.current_month_index
-    )
-)
-
-# Derived alignment values
-islamic_date_rotation_offset = alignment.rotation_offset
-days_elapsed_islamic_base = alignment.days_elapsed
-
-
-# In[2]:
-
-
-# make the out dir
-os.makedirs("out", exist_ok=True)
-
-
-# In[3]:
-
-
-# Get months to draw
-
-scale_factor = SCALE_FACTOR
-
-print(scale_factor)
-
-canvas_width = 11 * scale_factor
-width = inchToMilimeter(8 * scale_factor)
-outermost_radius = width / ( 2 * 3.14 / 12)
-# outermost_radius = inchToMilimeter(35)
-inner_radius = outermost_radius * 9.2 / 10
-month_thickness = (outermost_radius - inner_radius)
-date_box_height = month_thickness * 0.2
-
-# width = outermost_radius * 2 * 3.14 / 12 / 2
-extra_width_offset = 10
-width_center = inchToMilimeter(canvas_width) / 2 + extra_width_offset
-vertical_offset = 30 * scale_factor
-
-def date_rotation(month: Month) -> int:
-    date_angle_offset = -1 * (month.number - 1) * (360 / 12)
-    print(f"Offset for {month.name} is {date_angle_offset}")
-    return date_angle_offset    
-
-solarMonths = []
-
-for index, month in enumerate(solar_year.months):
-    name_upside_down = (index >= 3 and index < 9)
-    for day in month.num_days:
-        solarMonths.append(
-            MonthInstance(
-                name=month.name,
-                num_days=day,
-                color=month.color,
-                name_upside_down=name_upside_down,
-                date_on_top=False, # the outer month
-                date_box_height=date_box_height,
-                inner_radius=inner_radius,
-                outer_radius=outermost_radius,
-                date_angle_offset=date_rotation(month),
-            )
+    # Rotate Islamic months to start with current month
+    islamic_year = Year(
+        months=islamic_alignment.rotate_months(
+            islamic_year_canonical.months, alignment.current_month_index
         )
+    )
 
-# islamic_date_rotation_offset is now calculated dynamically from alignment params above
-    
-islamicMonths = []
-for month in islamic_year.months:
-    name_upside_down = (month.number > 3 and month.number <= 9)
-    for day in month.num_days:
-        islamicMonths.append(
-            MonthInstance(
-                name=month.name,
-                num_days=day,
-                color=month.color,
-                name_upside_down=name_upside_down,
-                date_on_top=True, # the outer month
-                date_box_height=date_box_height,
-                inner_radius=inner_radius - month_thickness,
-                outer_radius=outermost_radius - month_thickness,
-                date_angle_offset=date_rotation(month) + islamic_date_rotation_offset,
-            )
-        ) 
+    # Derived alignment values
+    islamic_date_rotation_offset = alignment.rotation_offset
+    days_elapsed_islamic_base = alignment.days_elapsed
 
 
-# In[4]:
+    # In[2]:
 
 
-month_offset = 4 * scale_factor # Use 0 to have solar/Islamic months touching in the print out
+    # make the out dir
+    os.makedirs("out", exist_ok=True)
 
-origin_first = Point(width_center, outermost_radius + vertical_offset)
 
-days_in_year = 366
+    # In[3]:
 
-def offsetPointBy(point: Point, x_offset: int, y_offset: int):
-    return Point(point.x + x_offset, point.y + y_offset)
 
-if scale_factor <= 0.5:
-    NUM_ROWS = 5
-    NUM_COLUMNS = 2
-elif scale_factor < 0.75:
-    NUM_ROWS = 4
-    NUM_COLUMNS = 1
-else:
-    NUM_ROWS = 2
-    NUM_COLUMNS = 1
+    # Calculate layout
+    layout = calculate_layout_params()
+    scale_factor = layout.scale_factor
 
-month_idx = 0
-page_num = 0
-pdfs = []
+    print(scale_factor)
 
-# Draw full scale pages
-while month_idx < len(solarMonths) - 1:
+    solarMonths = build_solar_month_instances(
+        solar_year, layout.date_box_height, layout.inner_radius, layout.outermost_radius
+    )
+
+    islamicMonths = build_islamic_month_instances(
+        islamic_year, layout.date_box_height, layout.inner_radius,
+        layout.outermost_radius, layout.month_thickness, islamic_date_rotation_offset
+    )
+
+
+    # In[4]:
+
+
+    origin_first = layout.origin
+
+    days_in_year = 366
+
+    NUM_ROWS = layout.num_rows
+    NUM_COLUMNS = layout.num_columns
+
+    month_idx = 0
+    page_num = 0
+    pdfs = []
+
+    # Draw full scale pages
+    while month_idx < len(solarMonths) - 1:
+        dwg = getVerticalPageCanvas() # getPageCanvas()
+        origin = origin_first
+        for col_num in range(NUM_COLUMNS):
+            for row_num in range(NUM_ROWS):
+                month_idx = row_num + NUM_ROWS*col_num + NUM_ROWS * NUM_COLUMNS * page_num
+
+                if month_idx < len(solarMonths):
+                    drawMonthParts(dwg, getMonth(solarMonths[month_idx], days_in_year, origin))
+                    origin = offsetPointBy(origin, 0, layout.month_offset)
+
+                if month_idx < len(islamicMonths):
+                    drawMonthParts(dwg, getMonth(islamicMonths[month_idx], days_in_year, origin))
+                    origin = offsetPointBy(origin, 0, (layout.month_thickness + layout.month_offset)*2.3)
+
+            # move to next column
+            origin = offsetPointBy(origin_first, layout.width * 1.05, 0)
+
+        svg_file = f"out/svg_{scale_factor}_{page_num}.svg"
+        pdf_file = f"out/calendar_page_{scale_factor}_{page_num}.pdf"
+
+        dwg.saveas(svg_file, pretty=True)
+        svg_to_pdf(svg_file, pdf_file)
+        os.remove(svg_file)
+        pdfs.append(pdf_file)
+
+        page_num += 1
+
+
+
+    # Draw summary page
+    def circle_form_factor(g, month, days_elapsed, days_in_year, origin):
+        g.translate(75, 50)
+        g.scale(0.3)
+        rot = calculate_circle_rotation(days_elapsed, month.num_days, days_in_year)
+        g.rotate(rot, center=origin)
+        g.translate(0, origin_first.y - origin.y)
+
+    month_idx = 0
+    page_num = 0
+    days_elapsed = 0 - solarMonths[0].num_days/2
+
+    # days_elapsed_islamic is now calculated dynamically from alignment params
+    # The base value comes from islamic_alignment module; we just adjust for centering
+    days_elapsed_islamic = days_elapsed_islamic_base - islamicMonths[0].num_days/2
+
     dwg = getVerticalPageCanvas() # getPageCanvas()
-    origin = origin_first
-    for col_num in range(NUM_COLUMNS):
-        for row_num in range(NUM_ROWS):
-            month_idx = row_num + NUM_ROWS*col_num + NUM_ROWS * NUM_COLUMNS * page_num
+    origin_first = Point(layout.width_center, layout.outermost_radius + layout.vertical_offset)
 
-            if month_idx < len(solarMonths):
-                drawMonthParts(dwg, getMonth(solarMonths[month_idx], days_in_year, origin))
-                origin = offsetPointBy(origin, 0, month_offset)
-            
-            if month_idx < len(islamicMonths):
-                drawMonthParts(dwg, getMonth(islamicMonths[month_idx], days_in_year, origin))
-                origin = offsetPointBy(origin, 0, (month_thickness + month_offset)*2.3)
-        
-        # move to next column 
-        origin = offsetPointBy(origin_first, width * 1.05, 0)
+    while month_idx < len(solarMonths) - 1:
+        origin = Point(origin_first.x, origin_first.y)
+        for col_num in range(NUM_COLUMNS):
+            for row_num in range(NUM_ROWS):
+                month_idx = row_num + NUM_ROWS*col_num + NUM_ROWS * NUM_COLUMNS * page_num
 
-    svg_file = f"out/svg_{scale_factor}_{page_num}.svg"
-    pdf_file = f"out/calendar_page_{scale_factor}_{page_num}.pdf"
+                if month_idx < len(solarMonths):
+                    month = solarMonths[month_idx]
+                    g = groupWithMonthParts(getMonth(month, days_in_year, origin))
+                    circle_form_factor(g, month, days_elapsed, days_in_year, origin)
+                    days_elapsed += month.num_days
+                    dwg.add(g)
+                    #origin = offsetPointBy(origin, 0, month_offset)
+
+
+                if month_idx < len(islamicMonths):
+                    month = islamicMonths[month_idx]
+                    g = groupWithMonthParts(getMonth(month, days_in_year, origin))
+                    circle_form_factor(g, month, days_elapsed_islamic, days_in_year, origin)
+                    days_elapsed_islamic += month.num_days
+                    dwg.add(g)
+                    #origin = offsetPointBy(origin, 0, month_thickness*2.3)
+
+            # move to next column
+            #origin = offsetPointBy(origin_first, width * 1.05, 0)
+
+        page_num += 1
+
+    print("saving pdf")
+    svg_file = f"out/svg_{scale_factor}_{page_num}_cover.svg"
+    pdf_file = f"out/calendar_page_{scale_factor}_{page_num}_cover.pdf"
 
     dwg.saveas(svg_file, pretty=True)
     svg_to_pdf(svg_file, pdf_file)
     os.remove(svg_file)
-    pdfs.append(pdf_file)
-    
-    page_num += 1
+    pdfs.insert(0, pdf_file)
+
+    # Generate the instructions PDF with the cover image embedded
+    import generate_instructions
+    cover_pdf = f"out/calendar_page_{scale_factor}_{page_num}_cover.pdf"
+    instructions_pdf = "v3 Instructions.pdf"
+    generate_instructions.generate_instructions_pdf(cover_pdf, instructions_pdf)
+
+    # Remove cover from pdfs list since it's now embedded in instructions
+    pdfs.remove(cover_pdf)
+
+    pdfizer.concat_pdfs([instructions_pdf] + pdfs, f"out/calendar_pages_{scale_factor}_COMPLETE.pdf")
+    print("Wrote the concatenated file!")
+
+    # Clean up intermediate PDFs
+    for pdf in pdfs:
+        print(f"removing {pdf}...")
+        os.remove(pdf)
+    print(f"removing {cover_pdf}...")
+    os.remove(cover_pdf)
+    print("and removed old pdfs")
+
+    print(scale_factor)
+    if SVG:
+        SVG(dwg.tostring())
 
 
-
-# Draw summary page
-def circle_form_factor(g, month, days_elapsed, days_in_year, origin):
-    g.translate(75, 50)
-    g.scale(0.3)
-    rot = 360.0 * (days_elapsed + month.num_days / 2)/days_in_year
-    g.rotate(rot, center=origin)
-    g.translate(0, origin_first.y - origin.y)
-
-month_idx = 0
-page_num = 0
-days_elapsed = 0 - solarMonths[0].num_days/2
-
-# days_elapsed_islamic is now calculated dynamically from alignment params
-# The base value comes from islamic_alignment module; we just adjust for centering
-days_elapsed_islamic = days_elapsed_islamic_base - islamicMonths[0].num_days/2 
-
-dwg = getVerticalPageCanvas() # getPageCanvas()
-origin_first = Point(width_center, outermost_radius + vertical_offset)
-
-while month_idx < len(solarMonths) - 1:
-    origin = Point(origin_first.x, origin_first.y)
-    for col_num in range(NUM_COLUMNS):
-        for row_num in range(NUM_ROWS):
-            month_idx = row_num + NUM_ROWS*col_num + NUM_ROWS * NUM_COLUMNS * page_num
-
-            if month_idx < len(solarMonths):
-                month = solarMonths[month_idx]
-                g = groupWithMonthParts(getMonth(month, days_in_year, origin))
-                circle_form_factor(g, month, days_elapsed, days_in_year, origin)
-                days_elapsed += month.num_days
-                dwg.add(g)
-                #origin = offsetPointBy(origin, 0, month_offset)
-                
-
-            if month_idx < len(islamicMonths):
-                month = islamicMonths[month_idx]
-                g = groupWithMonthParts(getMonth(month, days_in_year, origin))
-                circle_form_factor(g, month, days_elapsed_islamic, days_in_year, origin)
-                days_elapsed_islamic += month.num_days
-                dwg.add(g)
-                #origin = offsetPointBy(origin, 0, month_thickness*2.3)
-        
-        # move to next column 
-        #origin = offsetPointBy(origin_first, width * 1.05, 0)
-
-    page_num += 1
-
-print("saving pdf")
-svg_file = f"out/svg_{scale_factor}_{page_num}_cover.svg"
-pdf_file = f"out/calendar_page_{scale_factor}_{page_num}_cover.pdf"
-
-dwg.saveas(svg_file, pretty=True)
-svg_to_pdf(svg_file, pdf_file)
-os.remove(svg_file)
-pdfs.insert(0, pdf_file)
-
-# Generate the instructions PDF with the cover image embedded
-import generate_instructions
-cover_pdf = f"out/calendar_page_{scale_factor}_{page_num}_cover.pdf"
-instructions_pdf = "v3 Instructions.pdf"
-generate_instructions.generate_instructions_pdf(cover_pdf, instructions_pdf)
-
-# Remove cover from pdfs list since it's now embedded in instructions
-pdfs.remove(cover_pdf)
-
-pdfizer.concat_pdfs([instructions_pdf] + pdfs, f"out/calendar_pages_{scale_factor}_COMPLETE.pdf")
-print("Wrote the concatenated file!")
-
-# Clean up intermediate PDFs
-for pdf in pdfs:
-    print(f"removing {pdf}...")
-    os.remove(pdf)
-print(f"removing {cover_pdf}...")
-os.remove(cover_pdf)
-print("and removed old pdfs")
-
-print(scale_factor)
-if SVG:
-    SVG(dwg.tostring())
-
-
-
-
+if __name__ == "__main__" or is_notebook():
+    main()

--- a/python/test_arc_drawing.py
+++ b/python/test_arc_drawing.py
@@ -1,0 +1,210 @@
+"""
+Unit tests for arc_drawing module.
+
+Tests geometric calculation functions: coordinate conversion,
+arc construction, and dimensional arc properties.
+
+Run with: python -m pytest test_arc_drawing.py -v
+"""
+
+import math
+import unittest
+from primitives import Point, Arc, ArcDrawMode
+from arc_drawing import (
+    inchToMilimeter,
+    toRadian,
+    getCoordinatePoint,
+    getArc,
+    getDimensionalArc,
+    getPageCanvas,
+    getVerticalPageCanvas,
+)
+
+
+class TestInchToMillimeter(unittest.TestCase):
+    """Test unit conversion."""
+
+    def test_one_inch(self):
+        self.assertEqual(inchToMilimeter(1), 25)
+
+    def test_zero(self):
+        self.assertEqual(inchToMilimeter(0), 0)
+
+    def test_fractional(self):
+        self.assertEqual(inchToMilimeter(8.5), 212.5)
+
+
+class TestToRadian(unittest.TestCase):
+    """Test degree to radian conversion."""
+
+    def test_zero(self):
+        self.assertAlmostEqual(toRadian(0), 0)
+
+    def test_90_degrees(self):
+        self.assertAlmostEqual(toRadian(90), math.pi / 2)
+
+    def test_180_degrees(self):
+        self.assertAlmostEqual(toRadian(180), math.pi)
+
+    def test_360_degrees(self):
+        self.assertAlmostEqual(toRadian(360), 2 * math.pi)
+
+    def test_negative(self):
+        self.assertAlmostEqual(toRadian(-90), -math.pi / 2)
+
+
+class TestGetCoordinatePoint(unittest.TestCase):
+    """Test polar to cartesian conversion on circle."""
+
+    def test_0_degrees(self):
+        """0 degrees should be directly to the right of origin."""
+        p = getCoordinatePoint(Point(100, 100), 50, 0)
+        self.assertAlmostEqual(p.x, 150)
+        self.assertAlmostEqual(p.y, 100)
+
+    def test_90_degrees(self):
+        """90 degrees should be directly below origin (y increases downward in SVG)."""
+        p = getCoordinatePoint(Point(100, 100), 50, 90)
+        self.assertAlmostEqual(p.x, 100, places=5)
+        self.assertAlmostEqual(p.y, 150, places=5)
+
+    def test_180_degrees(self):
+        """180 degrees should be directly to the left."""
+        p = getCoordinatePoint(Point(100, 100), 50, 180)
+        self.assertAlmostEqual(p.x, 50, places=5)
+        self.assertAlmostEqual(p.y, 100, places=5)
+
+    def test_270_degrees(self):
+        """270 degrees should be directly above (negative y in SVG)."""
+        p = getCoordinatePoint(Point(100, 100), 50, 270)
+        self.assertAlmostEqual(p.x, 100, places=5)
+        self.assertAlmostEqual(p.y, 50, places=5)
+
+    def test_negative_90_degrees(self):
+        """-90 degrees should be above origin (same as 270)."""
+        p = getCoordinatePoint(Point(100, 100), 50, -90)
+        self.assertAlmostEqual(p.x, 100, places=5)
+        self.assertAlmostEqual(p.y, 50, places=5)
+
+    def test_distance_from_origin(self):
+        """Result should always be exactly 'radius' away from origin."""
+        origin = Point(50, 75)
+        radius = 30
+        for angle in [0, 45, 90, 135, 180, 225, 270, 315]:
+            p = getCoordinatePoint(origin, radius, angle)
+            dist = math.sqrt((p.x - origin.x) ** 2 + (p.y - origin.y) ** 2)
+            self.assertAlmostEqual(dist, radius, places=5,
+                                   msg=f"Distance wrong at {angle} degrees")
+
+
+class TestGetArc(unittest.TestCase):
+    """Test arc construction from angles."""
+
+    def test_small_arc_flag(self):
+        """Arc spanning less than 180 degrees should have large_arc_flag=0."""
+        arc = getArc(Point(100, 100), 50, 0, 90)
+        self.assertIn("0 0 1", arc.params)  # x_rotation=0, large_arc=0, sweep=1
+
+    def test_large_arc_flag(self):
+        """Arc spanning more than 180 degrees should have large_arc_flag=1."""
+        arc = getArc(Point(100, 100), 50, 0, 270)
+        self.assertIn("0 1 1", arc.params)  # x_rotation=0, large_arc=1, sweep=1
+
+    def test_exactly_180_degrees(self):
+        """Arc spanning exactly 180 degrees should have large_arc_flag=0."""
+        arc = getArc(Point(100, 100), 50, 0, 180)
+        self.assertIn("0 0 1", arc.params)
+
+    def test_sweep_clockwise(self):
+        """When start < stop, sweep_flag should be 1 (clockwise in SVG)."""
+        arc = getArc(Point(100, 100), 50, 10, 80)
+        self.assertTrue(arc.params.endswith("1"))
+
+    def test_sweep_counterclockwise(self):
+        """When start > stop, sweep_flag should be 0 (counter-clockwise)."""
+        arc = getArc(Point(100, 100), 50, 80, 10)
+        self.assertTrue(arc.params.endswith("0"))
+
+    def test_arc_start_stop_points_on_circle(self):
+        """Start and stop points should both be on the circle."""
+        origin = Point(100, 100)
+        radius = 50
+        arc = getArc(origin, radius, -45, 45)
+        for p in [arc.start, arc.stop]:
+            dist = math.sqrt((p.x - origin.x) ** 2 + (p.y - origin.y) ** 2)
+            self.assertAlmostEqual(dist, radius, places=5)
+
+    def test_arc_radius_preserved(self):
+        """The arc should carry the same radius it was created with."""
+        arc = getArc(Point(0, 0), 42, 0, 90)
+        self.assertEqual(arc.radius, 42)
+
+
+class TestGetDimensionalArc(unittest.TestCase):
+    """Test 2D (annular sector) arc construction."""
+
+    def test_outer_inner_relationship(self):
+        """Outer arc radius should be larger than inner arc radius."""
+        darc = getDimensionalArc(Point(100, 100), 60, 90, -45, 45)
+        self.assertGreater(darc.outerArc.radius, darc.innerArc.radius)
+
+    def test_stroke_default(self):
+        """Default stroke should be black."""
+        darc = getDimensionalArc(Point(100, 100), 60, 90, -45, 45)
+        self.assertEqual(darc.stroke, "black")
+
+    def test_fill_default(self):
+        """Default fill should be none."""
+        darc = getDimensionalArc(Point(100, 100), 60, 90, -45, 45)
+        self.assertEqual(darc.fill, "none")
+
+    def test_fill_custom(self):
+        """Custom fill should be preserved."""
+        darc = getDimensionalArc(Point(100, 100), 60, 90, -45, 45, fill="red")
+        self.assertEqual(darc.fill, "red")
+
+    def test_inner_arc_angles_reversed(self):
+        """Inner arc should have reversed start/stop angles for closed path."""
+        # The inner arc goes from stop_angle to start_angle (reverse direction)
+        # so that the path forms a closed shape
+        origin = Point(100, 100)
+        darc = getDimensionalArc(origin, 60, 90, -45, 45)
+        # Inner arc sweep is opposite to outer arc sweep
+        outer_sweep = "1" if darc.outerArc.params.endswith("1") else "0"
+        inner_sweep = "1" if darc.innerArc.params.endswith("1") else "0"
+        self.assertNotEqual(outer_sweep, inner_sweep)
+
+    def test_path_forms_closed_shape(self):
+        """The dimensional arc path should end by closing back to start."""
+        darc = getDimensionalArc(Point(100, 100), 60, 90, -45, 45)
+        path = darc.path()
+        # Path should end with L back to the outer arc start point
+        self.assertIn(f"L {darc.outerArc.start.pathText()}", path)
+
+
+class TestCanvasDimensions(unittest.TestCase):
+    """Test SVG canvas creation."""
+
+    def test_horizontal_canvas_size(self):
+        """Horizontal canvas should be 11x8.5 inches in mm."""
+        dwg = getPageCanvas()
+        # Width should be 11*25=275mm, height 8.5*25=212.5mm
+        self.assertIn("275mm", dwg.attribs.get("width", ""))
+        self.assertIn("212.5mm", dwg.attribs.get("height", ""))
+
+    def test_vertical_canvas_size(self):
+        """Vertical canvas should be 8.5x11 inches in mm."""
+        dwg = getVerticalPageCanvas()
+        self.assertIn("212.5mm", dwg.attribs.get("width", ""))
+        self.assertIn("275mm", dwg.attribs.get("height", ""))
+
+    def test_horizontal_vs_vertical_swapped(self):
+        """Horizontal and vertical canvases should have swapped dimensions."""
+        h = getPageCanvas()
+        v = getVerticalPageCanvas()
+        self.assertEqual(h.attribs["width"], v.attribs["height"])
+        self.assertEqual(h.attribs["height"], v.attribs["width"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/test_cal.py
+++ b/python/test_cal.py
@@ -1,5 +1,7 @@
 import unittest
-from make_cal import *        
+from primitives import Point, Arc, ArcDrawMode
+from arc_drawing import getDimensionalArc, getArc
+
 
 class Test_DimensionalArc(unittest.TestCase):
     def test_path(self):
@@ -37,8 +39,6 @@ class Test_Point(unittest.TestCase):
     def test_path(self):
         p = Point(5,2.2)
         self.assertEqual(p.pathText(), "5,2.2")
-
-print("I'm gonna kick some tests")
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test_calendar_drawings.py
+++ b/python/test_calendar_drawings.py
@@ -1,0 +1,171 @@
+"""
+Unit tests for calendar_drawings module.
+
+Tests the getMonth function which generates all SVG drawing elements
+for a single month (background arc, date boxes, date text, month name).
+
+Run with: python -m pytest test_calendar_drawings.py -v
+"""
+
+import unittest
+from primitives import Point, DimensionalArc, CurvedText, TextCenteredAroundPoint
+from calendar_data import MonthInstance
+from calendar_drawings import getMonth
+
+
+def _make_month_instance(
+    name="January",
+    num_days=31,
+    color="#aebbff",
+    name_upside_down=False,
+    date_on_top=False,
+    date_box_height=2.0,
+    inner_radius=80.0,
+    outer_radius=100.0,
+    date_angle_offset=0,
+) -> MonthInstance:
+    """Helper to create a MonthInstance with sensible defaults."""
+    return MonthInstance(
+        name=name,
+        num_days=num_days,
+        color=color,
+        name_upside_down=name_upside_down,
+        date_on_top=date_on_top,
+        date_box_height=date_box_height,
+        inner_radius=inner_radius,
+        outer_radius=outer_radius,
+        date_angle_offset=date_angle_offset,
+    )
+
+
+class TestGetMonthElementCount(unittest.TestCase):
+    """Test that getMonth produces the right number and type of elements."""
+
+    def test_element_count_31_day_month(self):
+        """31-day month: 1 background + 1 month name + 31 date boxes + 31 date texts = 64."""
+        month = _make_month_instance(num_days=31)
+        elements = getMonth(month, 366, Point(100, 100))
+        self.assertEqual(len(elements), 1 + 1 + 31 + 31)
+
+    def test_element_count_30_day_month(self):
+        """30-day month: 1 + 1 + 30 + 30 = 62."""
+        month = _make_month_instance(num_days=30, name="April")
+        elements = getMonth(month, 366, Point(100, 100))
+        self.assertEqual(len(elements), 62)
+
+    def test_element_count_29_day_month(self):
+        """29-day month (Feb leap): 1 + 1 + 29 + 29 = 60."""
+        month = _make_month_instance(num_days=29, name="February")
+        elements = getMonth(month, 366, Point(100, 100))
+        self.assertEqual(len(elements), 60)
+
+
+class TestGetMonthStructure(unittest.TestCase):
+    """Test the structure and types of generated elements."""
+
+    def test_first_element_is_background_arc(self):
+        """First element should be the colored background DimensionalArc."""
+        month = _make_month_instance(color="#ff0000")
+        elements = getMonth(month, 366, Point(100, 100))
+        self.assertIsInstance(elements[0], DimensionalArc)
+        self.assertEqual(elements[0].fill, "#ff0000")
+
+    def test_second_element_is_month_name(self):
+        """Second element should be the CurvedText month name."""
+        month = _make_month_instance(name="March")
+        elements = getMonth(month, 366, Point(100, 100))
+        self.assertIsInstance(elements[1], CurvedText)
+        self.assertEqual(elements[1].text, "March")
+
+    def test_date_boxes_are_dimensional_arcs(self):
+        """Date boxes (elements 2, 4, 6, ...) should be DimensionalArcs."""
+        month = _make_month_instance(num_days=5)
+        elements = getMonth(month, 366, Point(100, 100))
+        # Elements: [background, name, date_box_1, date_1, date_box_2, date_2, ...]
+        for i in range(5):
+            self.assertIsInstance(elements[2 + i * 2], DimensionalArc,
+                                 f"Element {2 + i * 2} should be a DimensionalArc date box")
+
+    def test_date_texts_are_text_centered(self):
+        """Date texts (elements 3, 5, 7, ...) should be TextCenteredAroundPoint."""
+        month = _make_month_instance(num_days=5)
+        elements = getMonth(month, 366, Point(100, 100))
+        for i in range(5):
+            self.assertIsInstance(elements[3 + i * 2], TextCenteredAroundPoint,
+                                 f"Element {3 + i * 2} should be a TextCenteredAroundPoint")
+
+    def test_date_text_values(self):
+        """Date texts should contain "1", "2", ..., "N"."""
+        month = _make_month_instance(num_days=5)
+        elements = getMonth(month, 366, Point(100, 100))
+        for i in range(5):
+            text_elem = elements[3 + i * 2]
+            self.assertEqual(text_elem.text, str(i + 1))
+
+
+class TestGetMonthDatePlacement(unittest.TestCase):
+    """Test date box placement (top vs bottom of arc)."""
+
+    def test_date_on_top_radius(self):
+        """When date_on_top=True, date boxes should be near outer_radius."""
+        month = _make_month_instance(date_on_top=True, inner_radius=80, outer_radius=100, date_box_height=5)
+        elements = getMonth(month, 366, Point(100, 100))
+        date_box = elements[2]  # First date box
+        # For date_on_top, date outer = month outer, date inner = outer - height
+        self.assertEqual(date_box.outerArc.radius, 100)
+        self.assertEqual(date_box.innerArc.radius, 95)  # 100 - 5
+
+    def test_date_on_bottom_radius(self):
+        """When date_on_top=False, date boxes should be near inner_radius."""
+        month = _make_month_instance(date_on_top=False, inner_radius=80, outer_radius=100, date_box_height=5)
+        elements = getMonth(month, 366, Point(100, 100))
+        date_box = elements[2]
+        # For date_on_top=False, date inner = month inner, date outer = inner + height
+        self.assertEqual(date_box.innerArc.radius, 80)
+        self.assertEqual(date_box.outerArc.radius, 85)  # 80 + 5
+
+
+class TestGetMonthNameOrientation(unittest.TestCase):
+    """Test month name arc direction for upside-down handling."""
+
+    def test_normal_month_name_arc_direction(self):
+        """Normal (not upside down) month: text arc goes start→stop."""
+        month = _make_month_instance(name_upside_down=False)
+        elements = getMonth(month, 366, Point(100, 100))
+        text = elements[1]
+        # start_angle < stop_angle → arc goes left to right
+        # The text arc start should be to the left (smaller x)
+        self.assertLess(text.arc.start.x, text.arc.stop.x)
+
+    def test_upside_down_month_name_arc_direction(self):
+        """Upside-down month: text arc goes stop→start (reversed)."""
+        month = _make_month_instance(name_upside_down=True)
+        elements = getMonth(month, 366, Point(100, 100))
+        text = elements[1]
+        # The text arc should be reversed - start.x > stop.x
+        self.assertGreater(text.arc.start.x, text.arc.stop.x)
+
+
+class TestGetMonthDateRotation(unittest.TestCase):
+    """Test that date_angle_offset propagates to date text elements."""
+
+    def test_offset_applied_to_date_texts(self):
+        """All date texts should use the month's date_angle_offset for rotation."""
+        offset = -60
+        month = _make_month_instance(num_days=3, date_angle_offset=offset)
+        elements = getMonth(month, 366, Point(100, 100))
+        for i in range(3):
+            text_elem = elements[3 + i * 2]
+            self.assertEqual(text_elem.rotation, offset)
+
+    def test_different_offsets_produce_different_rotations(self):
+        """Two months with different offsets should have different text rotations."""
+        m1 = _make_month_instance(num_days=1, date_angle_offset=0)
+        m2 = _make_month_instance(num_days=1, date_angle_offset=-30)
+        e1 = getMonth(m1, 366, Point(100, 100))
+        e2 = getMonth(m2, 366, Point(100, 100))
+        self.assertNotEqual(e1[3].rotation, e2[3].rotation)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/test_layout.py
+++ b/python/test_layout.py
@@ -1,0 +1,304 @@
+"""
+Unit tests for layout module.
+
+Tests pure computation functions: layout dimensions, pagination,
+month instance building, and geometric transformations.
+
+Run with: python -m pytest test_layout.py -v
+"""
+
+import unittest
+from primitives import Point, SCALE_FACTOR
+from calendar_data import Month, Year, solar_year, islamic_year_canonical
+from layout import (
+    calculate_layout_params,
+    get_pagination,
+    date_rotation,
+    offset_point_by,
+    calculate_circle_rotation,
+    build_solar_month_instances,
+    build_islamic_month_instances,
+)
+import islamic_alignment
+
+
+class TestCalculateLayoutParams(unittest.TestCase):
+    """Test layout dimension calculations."""
+
+    def test_default_uses_scale_factor_constant(self):
+        """Default layout should use SCALE_FACTOR from primitives."""
+        layout = calculate_layout_params()
+        self.assertEqual(layout.scale_factor, SCALE_FACTOR)
+
+    def test_radii_relationship(self):
+        """Inner radius must be less than outer radius, both positive."""
+        layout = calculate_layout_params(0.7)
+        self.assertGreater(layout.outermost_radius, 0)
+        self.assertGreater(layout.inner_radius, 0)
+        self.assertGreater(layout.outermost_radius, layout.inner_radius)
+
+    def test_month_thickness_is_difference_of_radii(self):
+        """Month thickness should equal outer - inner radius."""
+        layout = calculate_layout_params(0.7)
+        self.assertAlmostEqual(
+            layout.month_thickness,
+            layout.outermost_radius - layout.inner_radius,
+        )
+
+    def test_date_box_height_proportional_to_thickness(self):
+        """Date box height should be 20% of month thickness."""
+        layout = calculate_layout_params(0.7)
+        self.assertAlmostEqual(
+            layout.date_box_height,
+            layout.month_thickness * 0.2,
+        )
+
+    def test_larger_scale_produces_larger_radii(self):
+        """Increasing scale factor should increase all radii."""
+        small = calculate_layout_params(0.5)
+        large = calculate_layout_params(1.0)
+        self.assertGreater(large.outermost_radius, small.outermost_radius)
+        self.assertGreater(large.inner_radius, small.inner_radius)
+
+    def test_origin_y_accounts_for_radius_and_offset(self):
+        """Origin y should be outermost_radius + vertical_offset."""
+        layout = calculate_layout_params(0.7)
+        expected_y = layout.outermost_radius + layout.vertical_offset
+        self.assertAlmostEqual(layout.origin.y, expected_y)
+
+
+class TestGetPagination(unittest.TestCase):
+    """Test page layout determination."""
+
+    def test_small_scale(self):
+        """Scale <= 0.5 should use 5 rows, 2 columns."""
+        rows, cols = get_pagination(0.3)
+        self.assertEqual(rows, 5)
+        self.assertEqual(cols, 2)
+
+    def test_boundary_small_scale(self):
+        """Scale exactly 0.5 should use 5 rows, 2 columns."""
+        rows, cols = get_pagination(0.5)
+        self.assertEqual(rows, 5)
+        self.assertEqual(cols, 2)
+
+    def test_medium_scale(self):
+        """Scale between 0.5 and 0.75 should use 4 rows, 1 column."""
+        rows, cols = get_pagination(0.6)
+        self.assertEqual(rows, 4)
+        self.assertEqual(cols, 1)
+
+    def test_large_scale(self):
+        """Scale >= 0.75 should use 2 rows, 1 column."""
+        rows, cols = get_pagination(0.75)
+        self.assertEqual(rows, 2)
+        self.assertEqual(cols, 1)
+
+    def test_default_scale(self):
+        """Default scale factor 0.7 should use 4 rows, 1 column."""
+        rows, cols = get_pagination(0.7)
+        self.assertEqual(rows, 4)
+        self.assertEqual(cols, 1)
+
+    def test_layout_params_pagination_matches(self):
+        """LayoutParams should embed the same pagination as get_pagination."""
+        for sf in [0.3, 0.5, 0.6, 0.7, 0.75, 1.0]:
+            layout = calculate_layout_params(sf)
+            rows, cols = get_pagination(sf)
+            self.assertEqual(layout.num_rows, rows, f"Mismatch at scale {sf}")
+            self.assertEqual(layout.num_columns, cols, f"Mismatch at scale {sf}")
+
+
+class TestDateRotation(unittest.TestCase):
+    """Test date angle offset calculation."""
+
+    def test_first_month_zero_offset(self):
+        """Month number 1 should have zero rotation offset."""
+        m = Month(1, "January", [31], "#fff")
+        self.assertEqual(date_rotation(m), 0)
+
+    def test_second_month(self):
+        """Month number 2 should be offset by -30 degrees."""
+        m = Month(2, "February", [29], "#fff")
+        self.assertEqual(date_rotation(m), -30)
+
+    def test_seventh_month(self):
+        """Month number 7 should be offset by -180 degrees."""
+        m = Month(7, "July", [31], "#fff")
+        self.assertEqual(date_rotation(m), -180)
+
+    def test_twelfth_month(self):
+        """Month number 12 should be offset by -330 degrees."""
+        m = Month(12, "December", [31], "#fff")
+        self.assertEqual(date_rotation(m), -330)
+
+
+class TestOffsetPointBy(unittest.TestCase):
+    """Test point translation."""
+
+    def test_positive_offset(self):
+        p = offset_point_by(Point(10, 20), 5, 3)
+        self.assertEqual(p.x, 15)
+        self.assertEqual(p.y, 23)
+
+    def test_negative_offset(self):
+        p = offset_point_by(Point(10, 20), -5, -3)
+        self.assertEqual(p.x, 5)
+        self.assertEqual(p.y, 17)
+
+    def test_zero_offset(self):
+        p = offset_point_by(Point(10, 20), 0, 0)
+        self.assertEqual(p, Point(10, 20))
+
+
+class TestCalculateCircleRotation(unittest.TestCase):
+    """Test rotation angle for circular layout placement."""
+
+    def test_halfway_through_year(self):
+        """Month centered at day 183 of 366 should be at ~180 degrees."""
+        # days_elapsed such that days_elapsed + num_days/2 = 183
+        rot = calculate_circle_rotation(168.0, 30, 366)
+        self.assertAlmostEqual(rot, 360.0 * 183 / 366, places=5)
+
+    def test_start_of_year(self):
+        """First month centered around day 0 with 31 days → ~15.5/366 of circle."""
+        rot = calculate_circle_rotation(0, 31, 366)
+        expected = 360.0 * (0 + 31 / 2) / 366
+        self.assertAlmostEqual(rot, expected, places=5)
+
+    def test_full_year_sums_to_360(self):
+        """Sum of month widths should cover 360 degrees for 366-day year."""
+        days = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+        self.assertEqual(sum(days), 366)
+        # Each month contributes 360 * num_days / 366 degrees
+        total = sum(360.0 * d / 366 for d in days)
+        self.assertAlmostEqual(total, 360.0, places=5)
+
+
+class TestBuildSolarMonthInstances(unittest.TestCase):
+    """Test solar month instance creation."""
+
+    def test_count(self):
+        """Should produce 12 MonthInstance objects (one per month)."""
+        instances = build_solar_month_instances(solar_year, 2.0, 80.0, 100.0)
+        self.assertEqual(len(instances), 12)
+
+    def test_all_date_on_top_false(self):
+        """Solar months are the outer ring; date_on_top should be False."""
+        instances = build_solar_month_instances(solar_year, 2.0, 80.0, 100.0)
+        for mi in instances:
+            self.assertFalse(mi.date_on_top, f"{mi.name} should have date_on_top=False")
+
+    def test_upside_down_months(self):
+        """Months at index 3-8 (April through September) should be upside down."""
+        instances = build_solar_month_instances(solar_year, 2.0, 80.0, 100.0)
+        expected_upside_down = {"April", "May", "June", "July", "August", "September"}
+        for mi in instances:
+            if mi.name in expected_upside_down:
+                self.assertTrue(mi.name_upside_down, f"{mi.name} should be upside down")
+            else:
+                self.assertFalse(mi.name_upside_down, f"{mi.name} should NOT be upside down")
+
+    def test_radii_passed_through(self):
+        """Inner and outer radius should match the provided values."""
+        instances = build_solar_month_instances(solar_year, 2.0, 80.0, 100.0)
+        for mi in instances:
+            self.assertEqual(mi.inner_radius, 80.0)
+            self.assertEqual(mi.outer_radius, 100.0)
+
+    def test_total_days(self):
+        """Total days across all instances should be 366 (leap year)."""
+        instances = build_solar_month_instances(solar_year, 2.0, 80.0, 100.0)
+        total = sum(mi.num_days for mi in instances)
+        self.assertEqual(total, 366)
+
+    def test_first_month_is_january(self):
+        instances = build_solar_month_instances(solar_year, 2.0, 80.0, 100.0)
+        self.assertEqual(instances[0].name, "January")
+        self.assertEqual(instances[0].num_days, 31)
+
+    def test_date_angle_offsets_are_distinct(self):
+        """Each month should have a different date angle offset."""
+        instances = build_solar_month_instances(solar_year, 2.0, 80.0, 100.0)
+        offsets = [mi.date_angle_offset for mi in instances]
+        self.assertEqual(len(set(offsets)), 12)
+
+
+class TestBuildIslamicMonthInstances(unittest.TestCase):
+    """Test Islamic month instance creation."""
+
+    def test_count(self):
+        """Should produce 12 instances (one per Islamic month)."""
+        instances = build_islamic_month_instances(
+            islamic_year_canonical, 2.0, 80.0, 100.0, 20.0, -19
+        )
+        self.assertEqual(len(instances), 12)
+
+    def test_all_date_on_top_true(self):
+        """Islamic months are the inner ring; date_on_top should be True."""
+        instances = build_islamic_month_instances(
+            islamic_year_canonical, 2.0, 80.0, 100.0, 20.0, -19
+        )
+        for mi in instances:
+            self.assertTrue(mi.date_on_top, f"{mi.name} should have date_on_top=True")
+
+    def test_inner_radius_offset_by_month_thickness(self):
+        """Islamic inner_radius should be original inner_radius - month_thickness."""
+        thickness = 20.0
+        instances = build_islamic_month_instances(
+            islamic_year_canonical, 2.0, 80.0, 100.0, thickness, 0
+        )
+        for mi in instances:
+            self.assertEqual(mi.inner_radius, 80.0 - thickness)
+            self.assertEqual(mi.outer_radius, 100.0 - thickness)
+
+    def test_upside_down_based_on_month_number(self):
+        """Months with number 4-9 should be upside down."""
+        instances = build_islamic_month_instances(
+            islamic_year_canonical, 2.0, 80.0, 100.0, 20.0, 0
+        )
+        for mi in instances:
+            # The canonical month numbers are 1-12
+            month_obj = [m for m in islamic_year_canonical.months if m.name == mi.name][0]
+            if month_obj.number > 3 and month_obj.number <= 9:
+                self.assertTrue(mi.name_upside_down, f"{mi.name} (#{month_obj.number}) should be upside down")
+            else:
+                self.assertFalse(mi.name_upside_down, f"{mi.name} (#{month_obj.number}) should NOT be upside down")
+
+    def test_rotation_offset_applied(self):
+        """Islamic date_angle_offset should include the rotation offset."""
+        offset = -19
+        instances_with_offset = build_islamic_month_instances(
+            islamic_year_canonical, 2.0, 80.0, 100.0, 20.0, offset
+        )
+        instances_without_offset = build_islamic_month_instances(
+            islamic_year_canonical, 2.0, 80.0, 100.0, 20.0, 0
+        )
+        for with_off, without_off in zip(instances_with_offset, instances_without_offset):
+            self.assertAlmostEqual(
+                with_off.date_angle_offset,
+                without_off.date_angle_offset + offset,
+            )
+
+    def test_rotated_months_upside_down(self):
+        """After rotation, upside_down should follow reassigned month numbers."""
+        rotated_year = Year(
+            months=islamic_alignment.rotate_months(
+                islamic_year_canonical.months, 7  # Sha'ban first
+            )
+        )
+        instances = build_islamic_month_instances(
+            rotated_year, 2.0, 80.0, 100.0, 20.0, 0
+        )
+        # After rotation, month numbers are reassigned 1-12
+        # Months 4-9 should be upside down
+        for mi in instances:
+            rotated_month = [m for m in rotated_year.months if m.name == mi.name][0]
+            expected = rotated_month.number > 3 and rotated_month.number <= 9
+            self.assertEqual(mi.name_upside_down, expected,
+                           f"{mi.name} (rotated #{rotated_month.number}): "
+                           f"expected upside_down={expected}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Extract pure computation from make_cal.py into layout.py module:
- Layout dimension calculations (radii, spacing, pagination)
- Month instance building for solar and Islamic calendars
- Point offset and circle rotation helpers

Wrap make_cal.py orchestration in main() so importing the module
no longer triggers side effects (CLI parsing, file I/O, PDF generation).
Fix test_cal.py to import from specific modules instead of make_cal.

Add 79 new unit tests across three test files:
- test_layout.py: layout params, pagination, month instance building
- test_arc_drawing.py: coordinate math, arc construction, canvas dims
- test_calendar_drawings.py: month element structure, placement, orientation

https://claude.ai/code/session_01EPWVBabP4qYnq7FVJpt5nJ