### PR TITLE
Add ESLint configuration for monorepo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,11 @@ The Next.js web app (`app/`) provides a landing page with a PDF download button.
 - Co-locate test files with source code (e.g., `foo.ts` + `foo.test.ts`)
 - Run tests after each change to verify correctness
 
+**Linting:**
+- Run `npm run lint` from the root to lint the entire monorepo
+- Run `npm run lint:fix` to auto-fix issues
+- Prefix intentionally unused variables with `_` (e.g., `_unusedArg`)
+
 ## Documentation Guidelines
 
 - **Root `CLAUDE.md`**: Cross-cutting technical concepts, AI constraints

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -24,7 +24,8 @@ npm start
 | `npm run dev` | `next dev` | Start development server |
 | `npm run build` | `next build` | Build for production |
 | `npm start` | `next start` | Start production server |
-| `npm run lint` | `next lint` | Run ESLint |
+| `npm run lint` | `eslint .` | Run ESLint |
+| `npm run lint:fix` | `eslint . --fix` | Run ESLint with auto-fix |
 | `npm run typecheck` | `tsc --noEmit` | TypeScript type checking |
 | `npm test` | `vitest run` | Run tests once |
 | `npm run test:watch` | `vitest` | Run tests in watch mode |

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,30 @@
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    ignores: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/out/**",
+      "**/.next/**",
+      "**/coverage/**",
+      "web/**",
+    ],
+  },
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+        },
+      ],
+      "@typescript-eslint/no-explicit-any": "warn",
+    },
+  }
+);

--- a/node/CLAUDE.md
+++ b/node/CLAUDE.md
@@ -24,6 +24,8 @@ npm test
 | `npm test` | `vitest run` | Run tests once |
 | `npm run test:watch` | `vitest` | Run tests in watch mode |
 | `npm run test:coverage` | `vitest run --coverage` | Run tests with coverage |
+| `npm run lint` | `eslint .` | Run ESLint |
+| `npm run lint:fix` | `eslint . --fix` | Run ESLint with auto-fix |
 | `npm run typecheck` | `tsc --noEmit` | TypeScript type checking |
 | `npm run snapshots:generate` | `tsx scripts/generate-snapshots.ts` | Regenerate test snapshots |
 

--- a/node/package.json
+++ b/node/package.json
@@ -9,6 +9,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",
     "snapshots:generate": "tsx scripts/generate-snapshots.ts"
   },

--- a/node/src/lib/calendar-builder.ts
+++ b/node/src/lib/calendar-builder.ts
@@ -10,7 +10,6 @@ import { inchToMillimeter, drawMonthParts } from './geometry.ts';
 import { getMonth } from './month-renderer.ts';
 import {
   type MonthInstance,
-  type Month,
   solarYear,
   islamicYearCanonical,
 } from './calendar-data.ts';

--- a/node/src/lib/config.test.ts
+++ b/node/src/lib/config.test.ts
@@ -3,12 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import {
-  type LayoutConfig,
-  type ComputedLayout,
-  computeLayout,
-  DEFAULT_LAYOUT_CONFIG,
-} from './config.ts';
+import { computeLayout, DEFAULT_LAYOUT_CONFIG } from './config.ts';
 
 describe('LayoutConfig', () => {
   describe('DEFAULT_LAYOUT_CONFIG', () => {

--- a/node/src/lib/geometry.test.ts
+++ b/node/src/lib/geometry.test.ts
@@ -10,7 +10,7 @@ import {
   drawMonthParts,
   groupWithMonthParts,
 } from './geometry.ts';
-import { Point, Arc, DimensionalArc, resetTextPathIdCounter } from './primitives.ts';
+import { Point, resetTextPathIdCounter } from './primitives.ts';
 
 beforeEach(() => {
   resetTextPathIdCounter();

--- a/node/src/lib/month-renderer.test.ts
+++ b/node/src/lib/month-renderer.test.ts
@@ -64,8 +64,6 @@ describe('getMonth', () => {
     const elements = getMonth(month, daysInYear, origin);
 
     // Month width = 360 * numDays / daysInYear = 360 * 31 / 366 ≈ 30.49°
-    const expectedWidth = (360 * 31) / 366;
-
     // Background arc should span this width centered around -90°
     const background = elements[0];
     // We can't directly test angles, but we can check the arc exists

--- a/node/src/lib/month-renderer.ts
+++ b/node/src/lib/month-renderer.ts
@@ -7,7 +7,6 @@ import {
   Point,
   CurvedText,
   TextCenteredAroundPoint,
-  Circle,
   Drawable,
 } from './primitives.ts';
 import { getDimensionalArc, getArc } from './geometry.ts';

--- a/node/src/lib/pdf-generator.test.ts
+++ b/node/src/lib/pdf-generator.test.ts
@@ -7,7 +7,6 @@ import {
   createPdfGenerator,
   pngBufferToPdf,
   concatPdfBytes,
-  type PdfGeneratorOptions,
 } from './pdf-generator.ts';
 import type { SvgRenderer, SvgRenderResult } from './types.ts';
 import { PDFDocument } from 'pdf-lib';

--- a/node/src/renderers/resvg-renderer.test.ts
+++ b/node/src/renderers/resvg-renderer.test.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { PNG } from 'pngjs';
 import { createResvgRenderer, parseSizeToPoints } from './resvg-renderer.ts';
-import type { SvgRenderer, SvgRenderResult } from '../lib/types.js';
+import type { SvgRenderer } from '../lib/types.js';
 
 describe('parseSizeToPoints', () => {
   it('should parse mm values', () => {

--- a/node/src/svg-to-png.test.ts
+++ b/node/src/svg-to-png.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { svgToPng, parseSizeToPoints, SvgDimensions } from './svg-to-png.ts';
+import { svgToPng, parseSizeToPoints } from './svg-to-png.ts';
 
 describe('parseSizeToPoints', () => {
   it('should parse millimeters to points', () => {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,19 @@
 {
   "name": "circular-calendar-monorepo",
   "private": true,
+  "type": "module",
   "workspaces": [
     "node",
     "app"
   ],
   "scripts": {
-    "build": "npm run build --workspace=app"
+    "build": "npm run build --workspace=app",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.19.0",
+    "eslint": "^9.19.0",
+    "typescript-eslint": "^8.22.0"
   }
 }


### PR DESCRIPTION
## Summary
- Set up ESLint 9 with TypeScript support across both workspaces
- Remove unused type imports and variables flagged by the linter
- Update CLAUDE.md files with linting instructions

## Test plan
- [x] `npm run lint` passes with no errors
- [x] All tests pass in both workspaces
- [x] TypeScript type checking passes